### PR TITLE
Open sidebar by default and improve toggle accessibility and responsive styles

### DIFF
--- a/slotz/src/Layout.tsx
+++ b/slotz/src/Layout.tsx
@@ -3,7 +3,7 @@ import { NavLink, Outlet } from "react-router";
 import "./SidebarLayout.css";
 
 export default function Layout() {
-    const [sidebarOpen, setSidebarOpen] = useState(false);
+    const [sidebarOpen, setSidebarOpen] = useState(true);
 
     const closeSidebar = () => setSidebarOpen(false);
 
@@ -16,14 +16,15 @@ export default function Layout() {
     }, []);
 
     return (
-        <div className="layout">
+        <div className={`layout${sidebarOpen ? "" : " sidebar-collapsed"}`}>
             <button
-                className="hamburger"
+                className="sidebar-toggle"
                 aria-label={sidebarOpen ? "Close navigation" : "Open navigation"}
                 aria-expanded={sidebarOpen}
                 onClick={() => setSidebarOpen((open) => !open)}
             >
-                {sidebarOpen ? "✕" : "☰"}
+                <span className="toggle-icon" aria-hidden="true">{sidebarOpen ? "✕" : "☰"}</span>
+                <span className="toggle-label">{sidebarOpen ? "Hide sidebar" : "Show sidebar"}</span>
             </button>
 
             <aside className={`sidebar${sidebarOpen ? " sidebar-open" : ""}`}>

--- a/slotz/src/SidebarLayout.css
+++ b/slotz/src/SidebarLayout.css
@@ -9,9 +9,13 @@
     font-family: monospace;
 }
 
+.layout.sidebar-collapsed {
+    grid-template-columns: 0 1fr;
+}
+
 .sidebar {
     background: #1a2538;
-    padding: 2rem 1.5rem;
+    padding: 5rem 1.5rem 2rem;
     border-right: 1px solid #2c3a52;
     min-height: 100vh;
 }
@@ -51,28 +55,43 @@
     min-width: 0;
 }
 
-.hamburger {
-    display: none;
+.sidebar-toggle {
     position: fixed;
     top: 1rem;
     left: 1rem;
-    z-index: 200;
+    z-index: 250;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
     background: #2f66e0;
     color: white;
     border: none;
     border-radius: 8px;
-    padding: 0.5rem 0.75rem;
-    font-size: 1.25rem;
+    padding: 0.5rem 0.9rem;
+    font-size: 0.95rem;
+    font-weight: 600;
     cursor: pointer;
+}
+
+.toggle-icon {
+    font-size: 1.15rem;
+    line-height: 1;
+}
+
+.toggle-label {
+    white-space: nowrap;
+}
+
+.layout.sidebar-collapsed .sidebar {
+    overflow: hidden;
+    padding-left: 0;
+    padding-right: 0;
+    border-right: none;
 }
 
 @media (max-width: 768px) {
     .layout {
         grid-template-columns: 1fr;
-    }
-
-    .hamburger {
-        display: block;
     }
 
     .sidebar {
@@ -81,9 +100,14 @@
         left: 0;
         height: 100vh;
         width: 280px;
+        padding-top: 5rem;
         z-index: 100;
         transform: translateX(-100%);
         transition: transform 0.25s ease;
+    }
+
+    .layout.sidebar-collapsed {
+        grid-template-columns: 1fr;
     }
 
     .sidebar.sidebar-open {


### PR DESCRIPTION
### Motivation
- Make the sidebar visible by default and provide a clearer, more accessible toggle UI. 
- Add a dedicated collapsed layout state to allow collapsing the sidebar without breaking grid layout. 
- Improve responsive behavior so the sidebar slides in on small screens and the toggle remains usable. 

### Description
- Change initial sidebar state in `Layout.tsx` from `false` to `true` and update the root `div` to add a `sidebar-collapsed` class when closed. 
- Replace the old hamburger button with a `sidebar-toggle` button that includes a decorative `toggle-icon` span and a visible `toggle-label`, and keep `aria-*` attributes for accessibility. 
- Keep `NavLink` handlers to call `closeSidebar` and toggle `aside` classes to `sidebar-open` when visible. 
- Update `SidebarLayout.css` to add `.layout.sidebar-collapsed`, collapse/expand styles for the sidebar, refined paddings, z-index adjustments, `.toggle-icon`/`.toggle-label` rules, and mobile transform/transition behavior. 

### Testing
- Ran `npm run build` locally and the application bundle built successfully. 
- Ran `npm test` and unit tests completed without failures. 
- Ran `npm run lint` and no linting errors were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3dd7f193c832fbc0b75409b1bdb1e)